### PR TITLE
Fix plugin precedence

### DIFF
--- a/src/main/groovy/com/github/joselion/prettyjupiter/PrettyJupiterPlugin.groovy
+++ b/src/main/groovy/com/github/joselion/prettyjupiter/PrettyJupiterPlugin.groovy
@@ -4,8 +4,7 @@ import static org.gradle.api.tasks.testing.logging.TestExceptionFormat.SHORT
 
 import org.gradle.api.Project
 import org.gradle.api.Plugin
-
-import com.github.joselion.prettyjupiter.helpers.PrettyJupiterPluginException
+import org.gradle.api.plugins.JavaPlugin
 
 /**
  * A Gradle plugin to better log JUnit Jupiter tests when run from the Gradle
@@ -14,7 +13,7 @@ import com.github.joselion.prettyjupiter.helpers.PrettyJupiterPluginException
  */
 public class PrettyJupiterPlugin implements Plugin<Project> {
   public void apply(Project project) {
-    try {
+    project.plugins.withType(JavaPlugin) {
       final PrettyJupiterPluginExtension extension = project.extensions.create('prettyJupiter', PrettyJupiterPluginExtension)
       final PrettyLogger prettyLogger = new PrettyLogger(project, extension)
 
@@ -24,10 +23,7 @@ public class PrettyJupiterPlugin implements Plugin<Project> {
       }
 
       project.test.beforeSuite(prettyLogger.&logDescriptors)
-
       project.test.afterTest(prettyLogger.&logResults)
-    } catch(MissingPropertyException e) {
-      throw new PrettyJupiterPluginException('This plugin canm only be applied if a test task exist!', e)
     }
   }
 }

--- a/src/main/groovy/com/github/joselion/prettyjupiter/helpers/PrettyJupiterPluginException.groovy
+++ b/src/main/groovy/com/github/joselion/prettyjupiter/helpers/PrettyJupiterPluginException.groovy
@@ -1,8 +1,0 @@
-package com.github.joselion.prettyjupiter.helpers
-
-public class PrettyJupiterPluginException extends RuntimeException {
-
-  public PrettyJupiterPluginException(String message, Throwable cause) {
-    super(message, cause)
-  }
-}

--- a/src/test/groovy/com/github/joselion/prettyjupiter/PrettyJupiterPluginTest.groovy
+++ b/src/test/groovy/com/github/joselion/prettyjupiter/PrettyJupiterPluginTest.groovy
@@ -1,41 +1,41 @@
 package com.github.joselion.prettyjupiter
 
 import static org.gradle.api.tasks.testing.logging.TestExceptionFormat.SHORT
-import static org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
 
+import groovy.lang.MissingPropertyException
 import org.gradle.testfixtures.ProjectBuilder
 import org.gradle.api.Project
-import org.gradle.api.internal.plugins.PluginApplicationException
 import spock.lang.Specification
-
-import com.github.joselion.prettyjupiter.helpers.PrettyJupiterPluginException
 
 
 class PrettyJupiterPluginTest extends Specification {
 
-  def 'plugin applied when test task exist'() {
+  def 'plugin applied when test task exist'(String basePlugin) {
     given:
       final Project project = ProjectBuilder.builder().build()
 
     when:
-      project.plugins.apply('java')
       project.plugins.apply('com.github.joselion.pretty-jupiter')
+      project.plugins.apply(basePlugin)
 
     then:
       project.test.testLogging.exceptionFormat == SHORT
       project.test.testLogging.showStandardStreams == true
+
+    where:
+      basePlugin << ['java', 'java-library', 'groovy', 'java-gradle-plugin']
   }
 
   def 'plugin applied when test task *does not* exist'() {
     given:
       final Project project = ProjectBuilder.builder().build()
-
-    when:
       project.plugins.apply('com.github.joselion.pretty-jupiter')
 
+    when:
+      project.test
+
     then:
-      PluginApplicationException exception = thrown()
-      exception.cause instanceof PrettyJupiterPluginException
-      exception.cause.message == 'This plugin canm only be applied if a test task exist!'
+      MissingPropertyException exception = thrown()
+      exception.message == "Could not get unknown property 'test' for root project 'test' of type org.gradle.api.Project."
   }
 }


### PR DESCRIPTION
- Make plugin configuration lazy. Only set if `JavaTest` plugin type is invoked