### PR TITLE
Move plugin implementation to the test task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
   id 'nebula.lint' version '16.2.3'
 }
 
-version = '0.1.2'
+version = '1.0.0'
 
 dependencyLocking {
   lockAllConfigurations()

--- a/src/main/groovy/com/github/joselion/prettyjupiter/PrettyJupiterPlugin.groovy
+++ b/src/main/groovy/com/github/joselion/prettyjupiter/PrettyJupiterPlugin.groovy
@@ -5,6 +5,7 @@ import static org.gradle.api.tasks.testing.logging.TestExceptionFormat.SHORT
 import org.gradle.api.Project
 import org.gradle.api.Plugin
 import org.gradle.api.plugins.JavaPlugin
+import org.gradle.api.tasks.testing.Test
 
 /**
  * A Gradle plugin to better log JUnit Jupiter tests when run from the Gradle
@@ -14,17 +15,19 @@ import org.gradle.api.plugins.JavaPlugin
 public class PrettyJupiterPlugin implements Plugin<Project> {
   public void apply(Project project) {
     project.plugins.withType(JavaPlugin) {
-      final PrettyJupiterPluginExtension extension = project.extensions.create('prettyJupiter', PrettyJupiterPluginExtension)
-      final PrettyLogger prettyLogger = new PrettyLogger(project, extension)
+      project.tasks.withType(Test) { testTaks ->
+        final PrettyJupiterPluginExtension extension = project.extensions.create('prettyJupiter', PrettyJupiterPluginExtension)
+        final PrettyLogger prettyLogger = new PrettyLogger(project, extension)
 
-      project.test.testLogging {
-        exceptionFormat(SHORT)
-        showStandardStreams(true)
+        testTaks.testLogging {
+          exceptionFormat(SHORT)
+          showStandardStreams(true)
+        }
+
+        testTaks.beforeSuite(prettyLogger.&logDescriptors)
+        testTaks.afterTest(prettyLogger.&logResults)
+        testTaks.afterSuite(prettyLogger.&logSummary)
       }
-
-      project.test.beforeSuite(prettyLogger.&logDescriptors)
-      project.test.afterTest(prettyLogger.&logResults)
-      project.test.afterSuite(prettyLogger.&logSummary)
     }
   }
 }


### PR DESCRIPTION
- Use test task through `prokect.tasks.withType(Test)` closure
- Bump plugin version to `v1.0.0` for next release