### PR TITLE
Interop with Gradle Kotlin

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Using the [plugins DSL](https://docs.gradle.org/current/userguide/plugins.html#s
 
 ```groovy
 plugins {
-    id 'com.github.joselion.pretty-jupiter' version 'x.x.x'
+  id 'com.github.joselion.pretty-jupiter' version 'x.x.x'
 }
 ```
 
@@ -31,7 +31,7 @@ plugins {
 
 ```kotlin
 plugins {
-    id("com.github.joselion.pretty-jupiter") version "x.x.x"
+  id("com.github.joselion.pretty-jupiter") version "x.x.x"
 }
 ```
 
@@ -62,12 +62,12 @@ apply plugin: 'com.github.joselion.pretty-jupiter'
 
 ```kotlin
 buildscript {
-    repositories {
-        url = uri("https://plugins.gradle.org/m2/")
-    }
-    dependencies {
-        classpath("gradle.plugin.com.github.joselion.pretty-jupiter:pretty-jupiter:x.x.x")
-    }
+  repositories {
+    url = uri("https://plugins.gradle.org/m2/")
+  }
+  dependencies {
+    classpath("gradle.plugin.com.github.joselion.pretty-jupiter:pretty-jupiter:x.x.x")
+  }
 }
 
 apply(plugin = "com.github.joselion.pretty-jupiter")
@@ -96,15 +96,15 @@ The plugin can be customized adding a `prettyJupiter` closure to your `build.gra
 
 ```groovy
 prettyJupiter {
-    duration {
-        enabled = true
-        threshold = 75
-    }
+  duration {
+    enabled = true
+    threshold = 75
+  }
 
-    failure {
-        maxMessageLines = 15
-        maxTraceLines = 10
-    }
+  failure {
+    maxMessageLines = 15
+    maxTraceLines = 10
+  }
 }
 ```
 
@@ -114,15 +114,15 @@ prettyJupiter {
 
 ```kotlin
 prettyJupiter {
-    duration {
-        enabled.set(true)
-        threshold.set(75)
-    }
+  duration {
+    enabled.set(true)
+    threshold.set(75)
+  }
 
-    failure {
-        maxMessageLines.set(15)
-        maxTraceLines.set(10)
-    }
+  failure {
+    maxMessageLines.set(15)
+    maxTraceLines.set(10)
+  }
 }
 ```
 
@@ -140,12 +140,12 @@ Adding the following to `build.gradle` file:
 
 ```groovy
 test {
-    useJUnitPlatform()
+  useJUnitPlatform()
 
-    testLogging {
-        exceptionFormat 'short'
-        events 'started', 'skipped', 'failed'
-    }
+  testLogging {
+    exceptionFormat 'short'
+    events 'started', 'skipped', 'failed'
+  }
 }
 ```
 
@@ -160,13 +160,13 @@ import org.gradle.api.tasks.testing.logging.TestLogEvent.SKIPPED
 import org.gradle.api.tasks.testing.logging.TestLogEvent.STARTED
 
 tasks {
-    test {
-        useJUnitPlatform()
-        testLogging {
-            exceptionFormat = SHORT
-            events = setOf(STARTED, SKIPPED, FAILED)
-        }
+  test {
+    useJUnitPlatform()
+    testLogging {
+      exceptionFormat = SHORT
+      events = setOf(STARTED, SKIPPED, FAILED)
     }
+  }
 }
 ```
 
@@ -183,7 +183,7 @@ We only need Junit 5 configuration in `build.gradle(.kts)` file:
 
 ```groovy
 test {
-    useJUnitPlatform()
+  useJUnitPlatform()
 }
 ```
 
@@ -193,9 +193,9 @@ test {
 
 ```kotlin
 tasks {
-    test {
-        useJUnitPlatform()
-    }
+  test {
+    useJUnitPlatform()
+  }
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -16,13 +16,31 @@ JAVA_TOOL_OPTIONS="-Dfile.encoding=UTF8"
 ```
 
 Using the [plugins DSL](https://docs.gradle.org/current/userguide/plugins.html#sec:plugins_block):
+<details open>
+<summary>Groovy</summary>
+
 ```groovy
 plugins {
-  id 'com.github.joselion.pretty-jupiter' version 'x.x.x'
+    id 'com.github.joselion.pretty-jupiter' version 'x.x.x'
 }
 ```
 
+</details>
+<details>
+<summary>Kotlin</summary>
+
+```kotlin
+plugins {
+    id("com.github.joselion.pretty-jupiter") version "x.x.x"
+}
+```
+
+</details>
+
 Using [legacy plugin application](https://docs.gradle.org/current/userguide/plugins.html#sec:old_plugin_application):
+<details open>
+<summary>Groovy</summary>
+
 ```groovy
 buildscript {
   repositories {
@@ -38,6 +56,25 @@ buildscript {
 apply plugin: 'com.github.joselion.pretty-jupiter'
 ```
 
+</details>
+<details>
+<summary>Kotlin</summary>
+
+```kotlin
+buildscript {
+    repositories {
+        url = uri("https://plugins.gradle.org/m2/")
+    }
+    dependencies {
+        classpath("gradle.plugin.com.github.joselion.pretty-jupiter:pretty-jupiter:x.x.x")
+    }
+}
+
+apply(plugin = "com.github.joselion.pretty-jupiter")
+```
+
+</details>
+
 ## Extension properties
 The plugin can be customized adding a `prettyJupiter` closure to your `build.gradle` file and changing the following properties:
 
@@ -52,45 +89,117 @@ The plugin can be customized adding a `prettyJupiter` closure to your `build.gra
 
 ### Complete example
 
+
+
+<details open>
+<summary>Groovy</summary>
+
 ```groovy
 prettyJupiter {
-  duration {
-    enabled = true
-    threshold = 75
-  }
+    duration {
+        enabled = true
+        threshold = 75
+    }
 
-  failure {
-    maxMessageLines = 15
-    maxTraceLines = 10
-  }
+    failure {
+        maxMessageLines = 15
+        maxTraceLines = 10
+    }
 }
 ```
+
+</details>
+<details>
+<summary>Kotlin</summary>
+
+```kotlin
+prettyJupiter {
+    duration {
+        enabled.set(true)
+        threshold.set(75)
+    }
+
+    failure {
+        maxMessageLines.set(15)
+        maxTraceLines.set(10)
+    }
+}
+```
+
+</details>
 
 ## Illustrations
 
 ### Before
 Adding the following to `build.gradle` file:
 
+
+
+<details open>
+<summary>Groovy</summary>
+
 ```groovy
 test {
-  useJUnitPlatform()
+    useJUnitPlatform()
 
-  testLogging {
-    exceptionFormat 'short'
-    events 'started', 'skipped', 'failed'
-  }
+    testLogging {
+        exceptionFormat 'short'
+        events 'started', 'skipped', 'failed'
+    }
 }
 ```
+
+</details>
+<details>
+<summary>Kotlin</summary>
+
+```kotlin
+import org.gradle.api.tasks.testing.logging.TestExceptionFormat.SHORT
+import org.gradle.api.tasks.testing.logging.TestLogEvent.FAILED
+import org.gradle.api.tasks.testing.logging.TestLogEvent.SKIPPED
+import org.gradle.api.tasks.testing.logging.TestLogEvent.STARTED
+
+tasks {
+    test {
+        useJUnitPlatform()
+        testLogging {
+            exceptionFormat = SHORT
+            events = setOf(STARTED, SKIPPED, FAILED)
+        }
+    }
+}
+```
+
+</details>
 
 ![Before](assets/before.png)
 
 ### With `pretty-jupiter` plugin applied
-We only need Junit 5 configuration in `build.gradle` file:
+We only need Junit 5 configuration in `build.gradle(.kts)` file:
+
+
+<details open>
+<summary>Groovy</summary>
+
 ```groovy
 test {
-  useJUnitPlatform()
+    useJUnitPlatform()
 }
 ```
+
+</details>
+<details>
+<summary>Kotlin</summary>
+
+```kotlin
+tasks {
+    test {
+        useJUnitPlatform()
+    }
+}
+```
+
+</details>
 
 ![After (tests duration)](assets/after-durations.png)
 ![After (tests result)](assets/after-result.png)

--- a/src/main/groovy/com/github/joselion/prettyjupiter/PrettyJupiterExtension.groovy
+++ b/src/main/groovy/com/github/joselion/prettyjupiter/PrettyJupiterExtension.groovy
@@ -1,10 +1,14 @@
 package com.github.joselion.prettyjupiter
 
+import groovy.transform.CompileStatic
+import org.gradle.api.Action
+
 import javax.inject.Inject
 
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
 
+@CompileStatic
 class PrettyJupiterExtension {
 
   final Duration duration
@@ -17,16 +21,12 @@ class PrettyJupiterExtension {
     this.failure = objects.newInstance(Failure)
   }
 
-  def duration(Closure closure) {
-    closure.resolveStrategy = Closure.DELEGATE_FIRST
-    closure.delegate = duration
-    closure()
+  void duration(Action<Duration> durationAction) {
+    durationAction.execute(duration)
   }
 
-  def failure(Closure closure) {
-    closure.resolveStrategy = Closure.DELEGATE_FIRST
-    closure.delegate = failure
-    closure()
+  void failure(Action<Failure> failureAction) {
+    failureAction.execute(failure)
   }
 
   static class Duration {


### PR DESCRIPTION
As of version 1.3.4 pretty-jupiter plugin won't work correctly with
extension fields defined in `build.gradle.kts`. This PRs makes interop
possible. More over I've extended readme to be more friendly for kotlin
devs.