### PR TITLE
Allow settting up custom threshold for different tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,14 +76,15 @@ apply(plugin = "com.github.joselion.pretty-jupiter")
 ## Extension properties
 The plugin can be customized adding a `prettyJupiter` closure to your `build.gradle` file and changing the following properties:
 
-| Property                | Default   | Description |
-| ----------------------- |:---------:| ----------- |
-| duration                | -         | Closure to configure the test durations logged |
-| duration.enabled        | `true`    | If `true`, shows each test execution duration |
-| duration.threshold      | `75`      | Time threshold in milliseconds. If the test duration is `>=` than this value, it'll be colored <span style="color:red">RED</span>, if it's `>=` than half of this value, it'll be <span style="color:yellow">YELLOW</span>, otherwise it'll be white. |
-| failure                 | -         | Closure to configure the test failures logged |
-| failure.maxMessageLines | `15`      | The number of lines of the exception message to display. Note that some exception messages may include some stack trace on it |
-| failure.maxTraceLines   | `10`      | The number of lines of the exception stack trace to display |
+| Property                      | Default        | Description |
+| ------------------------------|:--------------:| ----------- |
+| duration                      | -              | Closure to configure the test durations logged |
+| duration.enabled              | `true`         | If `true`, shows each test execution duration |
+| duration.threshold            | `75`           | Time threshold in milliseconds. If the test duration is `>=` than this value, it'll be colored <span style="color:red">RED</span>, if it's `>=` than half of this value, it'll be <span style="color:yellow">YELLOW</span>, otherwise it'll be white. |
+| duration.customThreshold      | empty map      | Map that contains task name as a key and its custom threshold as a value. When customThreshold is present and contains running task, duration.threshold is overriden|
+| failure                       | -              | Closure to configure the test failures logged |
+| failure.maxMessageLines       | `15`           | The number of lines of the exception message to display. Note that some exception messages may include some stack trace on it |
+| failure.maxTraceLines         | `10`           | The number of lines of the exception stack trace to display |
 
 ### Complete example
 
@@ -97,6 +98,7 @@ prettyJupiter {
   duration {
     enabled = true
     threshold = 75
+    customThreshold = [test : 100, integrationTest : 150]  
   }
 
   failure {
@@ -116,6 +118,8 @@ prettyJupiter {
   duration {
     enabled.set(true)
     threshold.set(75)
+    customThreshold.put("test", 100)
+    customThreshold.put("integrationTest", 10000)
   }
 
   failure {

--- a/src/e2e/groovy/com/github/joselion/prettyjupiter/PrettyJupiterPluginE2E.groovy
+++ b/src/e2e/groovy/com/github/joselion/prettyjupiter/PrettyJupiterPluginE2E.groovy
@@ -154,21 +154,21 @@ class PrettyJupiterPluginE2E extends Specification {
     def buildGradle = new File(projectDir, 'build.gradle')
     buildGradle.bytes = []
     buildGradle << """\
-        |plugins {
-        |  id('java')
-        |  id('com.github.joselion.pretty-jupiter')
-        |}
-        |
-        |prettyJupiter {
-        |  duration.customThreshold = [test : 100, integrationTest : 200]
-        |}
-        |
-        |task showThreshold() {
-        |  print('Test threshold: ' + prettyJupiter.duration.customThreshold.get().get('test'))
-        |  print('Integration test threshold: ' + prettyJupiter.duration.customThreshold.get().get('integrationTest'))
-        |}
-      |"""
-            .stripMargin()
+      |plugins {
+      |  id('java')
+      |  id('com.github.joselion.pretty-jupiter')
+      |}
+      |
+      |prettyJupiter {
+      |  duration.customThreshold = [test : 100, integrationTest : 200]
+      |}
+      |
+      |task showThreshold() {
+      |  print('Test threshold: ' + prettyJupiter.duration.customThreshold.get().get('test'))
+      |  print('Integration test threshold: ' + prettyJupiter.duration.customThreshold.get().get('integrationTest'))
+      |}
+    |"""
+    .stripMargin()
 
     when:
     def runner = GradleRunner.create()

--- a/src/main/groovy/com/github/joselion/prettyjupiter/PrettyLogger.groovy
+++ b/src/main/groovy/com/github/joselion/prettyjupiter/PrettyLogger.groovy
@@ -120,7 +120,7 @@ class PrettyLogger {
 
     if (duration.enabled.get()) {
       final Long timeDiff = result.getEndTime() - result.getStartTime()
-      final Long threshold = duration.threshold.get()
+      final Long threshold = duration.getThreshold(testTask)
       final Colors color = timeDiff >= threshold
         ? Colors.RED
         : timeDiff >= threshold / 2
@@ -133,5 +133,4 @@ class PrettyLogger {
 
     return ''
   }
-  
 }

--- a/src/test/groovy/com/github/joselion/prettyjupiter/PrettyJupiterExtensionTest.groovy
+++ b/src/test/groovy/com/github/joselion/prettyjupiter/PrettyJupiterExtensionTest.groovy
@@ -66,38 +66,36 @@ class PrettyJupiterExtensionTest extends Specification {
 
   def 'returns custom threshold when exists'() {
     given:
-    final Project project = ProjectBuilder.builder().build()
-    final PrettyJupiterExtension extension = project.extensions.create('prettyJupiter', PrettyJupiterExtension)
-    final Test testTask = Stub(Test) {
-            toString() >> "task ':test'"
-    }
-    def testCustomThreshold = 100
-    extension.duration.customThreshold.put('test', testCustomThreshold)
+      final Project project = ProjectBuilder.builder().build()
+      final PrettyJupiterExtension extension = project.extensions.create('prettyJupiter', PrettyJupiterExtension)
+      final Test testTask = Stub(Test) {
+        toString() >> "task ':test'"
+      }
+      def testCustomThreshold = 100
+      extension.duration.customThreshold.put('test', testCustomThreshold)
 
     when:
-    Long duration = extension.getDuration().getThreshold(testTask)
-
+      Long duration = extension.getDuration().getThreshold(testTask)
 
     then:
-    duration == testCustomThreshold
+      duration == testCustomThreshold
   }
 
   def 'returns default threshold when custom threshold doesnt exist'() {
     given:
-    final Project project = ProjectBuilder.builder().build()
-    final PrettyJupiterExtension extension = project.extensions.create('prettyJupiter', PrettyJupiterExtension)
-    final Test testTask = Stub(Test) {
-      toString() >> "task ':integrationTest'"
-    }
-    extension.duration.customThreshold.put('test', 100)
-    def defaultThreshold = 150
-    extension.duration.threshold = defaultThreshold
+      final Project project = ProjectBuilder.builder().build()
+      final PrettyJupiterExtension extension = project.extensions.create('prettyJupiter', PrettyJupiterExtension)
+      final Test testTask = Stub(Test) {
+        toString() >> "task ':integrationTest'"
+      }
+      extension.duration.customThreshold.put('test', 100)
+      def defaultThreshold = 150
+      extension.duration.threshold = defaultThreshold
 
     when:
-    Long duration = extension.getDuration().getThreshold(testTask)
-
+      Long duration = extension.getDuration().getThreshold(testTask)
 
     then:
-    duration == defaultThreshold
+      duration == defaultThreshold
   }
 }


### PR DESCRIPTION
Within my business project, we use pretty-jupiter and display test logs while building. We have both unit and integration tests and they have significant duration difference. Setting up duration.threshold is not enough for this case. I've implemented customThreshold map in extension to store task name (e.g 'test' or 'integrationTest') and custom threshold value assigned to it. Custom threshold, when currently running task is present in map, overrides duration.threshold and gives the opportunity for better test logs customization.