### PR TITLE
chore(release): Fix vcsUrl issue

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -135,7 +135,7 @@ jacocoTestReport {
 
 gradlePlugin {
   website = 'https://joselion.github.io/pretty-jupiter/'
-  vcsUrl = 'https://github.com/JoseLion/pretty-jupiter'
+  vcsUrl = 'https://github.com/joselion/pretty-jupiter'
 
   plugins {
     prettyJupiter {


### PR DESCRIPTION
Lowercase `vcsUrl` to workaround https://github.com/gradle/plugin-portal-requests/issues/221.